### PR TITLE
Change toptable$Sig to Sig to avoid ggplot warning

### DIFF
--- a/R/EnhancedVolcano.R
+++ b/R/EnhancedVolcano.R
@@ -436,7 +436,7 @@ EnhancedVolcano <- function(
       geom_point(
         aes(
           color = factor(names(colCustom)),
-          shape = toptable$Sig),
+          shape = Sig),
         alpha = colAlpha,
         size = pointSize,
         na.rm = TRUE) +
@@ -486,7 +486,7 @@ EnhancedVolcano <- function(
         # are added to aes, too.
         geom_point(
           aes(
-            color = toptable$Sig,
+            color = Sig,
             shape = factor(names(shapeCustom))),
           alpha = colAlpha,
           size = pointSize,
@@ -529,7 +529,7 @@ EnhancedVolcano <- function(
         # are added to aes, too.
         geom_point(
           aes(
-            color = toptable$Sig,
+            color = Sig,
             shape = factor(names(shapeCustom))),
           alpha = colAlpha,
           size = pointSize,
@@ -565,7 +565,7 @@ EnhancedVolcano <- function(
             size = legendIconSize))) +
 
         geom_point(
-          aes(color = toptable$Sig),
+          aes(color = Sig),
           alpha = colAlpha,
           shape = shape,
           size = pointSize,
@@ -625,8 +625,8 @@ EnhancedVolcano <- function(
 
         geom_point(
           aes(
-            color = toptable$Sig,
-            shape = toptable$Sig),
+            color = Sig,
+            shape = Sig),
           alpha = colAlpha,
           size = pointSize,
           na.rm = TRUE) +
@@ -660,7 +660,7 @@ EnhancedVolcano <- function(
         geom_point(
           aes(
             color = yvals,
-            shape = toptable$Sig),
+            shape = Sig),
           alpha = colAlpha,
           size = pointSize,
           na.rm = TRUE) +


### PR DESCRIPTION
In newer versions of ggplot2 (I tested on 3.3.2, R 4.0.2) using `$` in
`aes()` results in a warning
(https://github.com/tidyverse/ggplot2/issues/2693), specifically,
"Warning: Use of `toptable$Sig` is discouraged. Use `Sig` instead." I
changed `factor(Sig)` to `toptable$Sig` in the last commit to allow
`legendDropLevels` to work. Changing this to simply `Sig` appears to be
the most idiomatic way, the warning is removed and all functionality
appears to be retained.