### PR TITLE
make labCol order consistent with selectLabs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(
     person("Emir", "Turkes", role = c("ctb")),
     person("Benjamin", "Ostendorf", role = c("ctb")),
     person("Andrea", "Grioni", role = c("ctb")),
-    person("Myles", "Lewis", role = c("aut")))
+    person("Myles", "Lewis", role = c("aut")),
+    person("Tianyi", "Shi", role = c("ctb"))),
 Maintainer: Kevin Blighe <kevin@clinicalbioinformatics.co.uk>
 Description: Volcano plots represent a useful way to visualise the results of differential expression analyses. Here, we present a highly-configurable function that produces publication-ready volcano plots. EnhancedVolcano will attempt to fit as many point labels in the plot window as possible, thus avoiding 'clogging' up the plot with labels that could not otherwise have been read. Other functionality allows the user to identify up to 4 different types of attributes in the same plot space via colour, shape, size, and shade parameter configurations.
 License: GPL-3

--- a/R/EnhancedVolcano.R
+++ b/R/EnhancedVolcano.R
@@ -796,123 +796,26 @@ EnhancedVolcano <- function(
     plot <- plot + theme(panel.grid.minor = element_blank())
   }
 
-  # user has specified to draw with geom_text or geom_label?
-  if (!boxedLabels) {
-
-    # For labeling with geom_[text|label]_repel and
-    # geom_[text|label] with check_overlap = TRUE, 4 possible
-    # scenarios can arise
-    if (drawConnectors && is.null(selectLab)) {
-
-      if (arrowheads) {
-        arr <- arrow(length = lengthConnectors,
-          type = typeConnectors, ends = endsConnectors)
-      } else {
-        arr <- NULL
-      }
-
-      plot <- plot + geom_text_repel(
-        data = subset(toptable,
-          toptable[[y]] < pCutoff &
-            abs(toptable[[x]]) > FCcutoff),
-        aes(label = subset(toptable,
-          toptable[[y]] < pCutoff &
-            abs(toptable[[x]]) > FCcutoff)[["lab"]]),
-        xlim = c(NA, NA),
-        ylim = c(NA, NA),
-        size = labSize,
-        segment.color = colConnectors,
-        segment.size = widthConnectors,
-        arrow = arr,
-        colour = labCol,
-        fontface = labFace,
-        parse = parseLabels,
-        na.rm = TRUE,
-        direction = directionConnectors,
-        max.overlaps = max.overlaps,
-        min.segment.length = min.segment.length)
-
-    } else if (drawConnectors && !is.null(selectLab)) {
-
-      if (arrowheads) {
-        arr <- arrow(length = lengthConnectors,
-          type = typeConnectors, ends = endsConnectors)
-      } else {
-        arr <- NULL
-      }
-
-      plot <- plot + geom_text_repel(
-        data = subset(toptable,
-          !is.na(toptable[['lab']])),
-        aes(label = subset(toptable,
-          !is.na(toptable[['lab']]))[['lab']]),
-        xlim = c(NA, NA),
-        ylim = c(NA, NA),
-        size = labSize,
-        segment.color = colConnectors,
-        segment.size = widthConnectors,
-        arrow = arr,
-        colour = labCol,
-        fontface = labFace,
-        parse = parseLabels,
-        na.rm = TRUE,
-        direction = directionConnectors,
-        max.overlaps = max.overlaps,
-        min.segment.length = min.segment.length)
-
-    } else if (!drawConnectors && !is.null(selectLab)) {
-
-      plot <- plot + geom_text(
-        data = subset(toptable,
-          !is.na(toptable[['lab']])),
-        aes(
-          label = subset(toptable,
-            !is.na(toptable[['lab']]))[['lab']]),
-        size = labSize,
-        check_overlap = TRUE,
-        colour = labCol,
-        fontface = labFace,
-        parse = parseLabels,
-        na.rm = TRUE)
-
-    } else if (!drawConnectors && is.null(selectLab)) {
-
-      plot <- plot + geom_text(
-        data = subset(toptable,
-          toptable[[y]] < pCutoff &
-            abs(toptable[[x]]) > FCcutoff),
-        aes(label = subset(toptable,
-          toptable[[y]] < pCutoff &
-            abs(toptable[[x]]) > FCcutoff)[['lab']]),
-        size = labSize,
-        check_overlap = TRUE,
-        colour = labCol,
-        fontface = labFace,
-        parse = parseLabels,
-        na.rm = TRUE)
-    }
-
+  if (arrowheads) {
+    arr <- arrow(length = lengthConnectors,
+      type = typeConnectors, ends = endsConnectors)
   } else {
+    arr <- NULL
+  }
 
-    # For labeling with geom_[text|label]_repel and
-    # geom_[text|label] with check_overlap = TRUE, 4 possible
-    # scenarios can arise
-    if (drawConnectors && is.null(selectLab)) {
-
-      if (arrowheads) {
-        arr <- arrow(length = lengthConnectors,
-          type = typeConnectors, ends = endsConnectors)
-      } else {
-        arr <- NULL
-      }
-
-      plot <- plot + geom_label_repel(
-        data = subset(toptable,
+  if (is.null(selectLab)) {
+    lab_data <- subset(toptable,
           toptable[[y]] < pCutoff &
-            abs(toptable[[x]]) > FCcutoff),
-        aes(label = subset(toptable,
-          toptable[[y]]<pCutoff &
-            abs(toptable[[x]]) > FCcutoff)[['lab']]),
+            abs(toptable[[x]]) > FCcutoff)
+  } else {
+    lab_data = subset(toptable, !is.na(toptable[['lab']]))
+  }
+
+  geom_volcano_lab <- function(fn, fn_repel, data){
+    if (drawConnectors) {
+      fn_repel(
+        data = lab_data,
+        aes(label = lab),
         xlim = c(NA, NA),
         ylim = c(NA, NA),
         size = labSize,
@@ -926,65 +829,24 @@ EnhancedVolcano <- function(
         direction = directionConnectors,
         max.overlaps = max.overlaps,
         min.segment.length = min.segment.length)
-
-    } else if (drawConnectors && !is.null(selectLab)) {
-
-      if (arrowheads) {
-        arr <- arrow(length = lengthConnectors,
-          type = typeConnectors, ends = endsConnectors)
-      } else {
-        arr <- NULL
-      }
-
-      plot <- plot + geom_label_repel(
-        data = subset(toptable,
-          !is.na(toptable[['lab']])),
-        aes(label = subset(toptable,
-          !is.na(toptable[['lab']]))[['lab']]),
-        xlim = c(NA, NA),
-        ylim = c(NA, NA),
+    } else {
+      fn(
+        data = lab_data,
+        aes(label = lab),
         size = labSize,
-        segment.color = colConnectors,
-        segment.size = widthConnectors,
-        arrow = arr,
-        colour = labCol,
-        fontface = labFace,
-        parse = parseLabels,
-        na.rm = TRUE,
-        direction = directionConnectors,
-        max.overlaps = max.overlaps,
-        min.segment.length = min.segment.length)
-
-    } else if (!drawConnectors && !is.null(selectLab)) {
-
-      plot <- plot + geom_label(
-        data = subset(toptable,
-          !is.na(toptable[["lab"]])),
-        aes(
-          label = subset(toptable,
-            !is.na(toptable[['lab']]))[['lab']]),
-        size = labSize,
+        check_overlap = TRUE,
         colour = labCol,
         fontface = labFace,
         parse = parseLabels,
         na.rm = TRUE)
-
-    } else if (!drawConnectors && is.null(selectLab)) {
-
-      plot <- plot + geom_label(
-        data = subset(toptable,
-          toptable[[y]] < pCutoff &
-            abs(toptable[[x]]) > FCcutoff),
-        aes(label = subset(toptable,
-          toptable[[y]] < pCutoff &
-            abs(toptable[[x]]) > FCcutoff)[['lab']]),
-        size = labSize,
-        colour = labCol,
-        fontface = labFace,
-        parse = parseLabels,
-        na.rm = TRUE)
-
     }
+  }
+  
+  # user has specified to draw with geom_text or geom_label?
+  plot <- plot + if (!boxedLabels) {
+    geom_volcano_lab(geom_text, geom_text_repel)
+  } else {
+     geom_volcano_lab(geom_label, geom_label_repel)
   }
 
   # encircle

--- a/R/EnhancedVolcano.R
+++ b/R/EnhancedVolcano.R
@@ -803,12 +803,12 @@ EnhancedVolcano <- function(
     arr <- NULL
   }
 
-  if (is.null(selectLab)) {
-    lab_data <- subset(toptable,
-          toptable[[y]] < pCutoff &
+  lab_data <- if (is.null(selectLab)) {
+    subset(toptable, toptable[[y]] < pCutoff &
             abs(toptable[[x]]) > FCcutoff)
   } else {
-    lab_data = subset(toptable, !is.na(toptable[['lab']]))
+    table_sel <- subset(toptable, !is.na(toptable$lab))
+    table_sel[order(factor(table_sel$lab, levels = selectLab)),]
   }
 
   geom_volcano_lab <- function(fn, fn_repel, data){

--- a/README.md
+++ b/README.md
@@ -756,6 +756,7 @@ and suggestions from:
   - Benjamin Ostendorf
   - Cristian (github.com/ccruizm)
   - Quan Le (Yale University)
+  - Tianyi Shi (github.com/TianyiShi2001)
 
 # Session info
 


### PR DESCRIPTION
Currently, when we have `selectLab` and `labCol` with multiple values, the order of the colors is not consistent with `selectLab`. An example (extended from the first example in the vignette):

```r
library('DESeq2')
library(EnhancedVolcano)
library(airway)
data(airway)

dds <- DESeqDataSet(airway, design = ~ cell + dex)
dds <- DESeq(dds, betaPrior=FALSE)
res <- results(dds,
               contrast = c('dex','trt','untrt'))
res <- lfcShrink(dds,
                 contrast = c('dex','trt','untrt'), res=res, type = 'normal')

EnhancedVolcano(res,
                lab = rownames(res),
                x = 'log2FoldChange',
                y = 'pvalue', selectLab = c('ENSG00000125148', 'ENSG00000000419'),
                labCol = c('brown', 'gray'))

``` 

<img width="723" alt="スクリーンショット 2022-12-13 14 57 00" src="https://user-images.githubusercontent.com/38644266/207367246-5464d6ef-4937-4210-a95f-2f97dd6a1303.png">

This PR resolves this issue by reordering the toptable subset according to the order of selectLab before plotting the labels.

Also I did some refactoring to minimize repetitions.
