### PR TITLE
replaced guide=FALSE to guide=none

### DIFF
--- a/R/EnhancedVolcano.R
+++ b/R/EnhancedVolcano.R
@@ -700,7 +700,7 @@ EnhancedVolcano <- function(
             FC = shape[2],
             P = shape[3],
             FC_P = shape[4]),
-          guide = FALSE,
+          guide = "none",
           drop = legendDropLevels)
 
     } else {
@@ -728,7 +728,7 @@ EnhancedVolcano <- function(
             FC = shape[2],
             P = shape[3],
             FC_P = shape[4]),
-          guide = FALSE,
+          guide = "none",
           drop = legendDropLevels)
 
     }


### PR DESCRIPTION
This PR is due to warning message in ggplot2 3.3.4
The `guide` argument in `scale_*()` cannot be `FALSE`. This was deprecated in ggplot2 3.3.4.
ℹ Please use "none" instead.